### PR TITLE
Update i18next-sync-fs-backend namespace

### DIFF
--- a/plugins-and-utils.md
+++ b/plugins-and-utils.md
@@ -43,7 +43,7 @@ backend           | description
 [fetch backend](https://github.com/perrin4869/i18next-fetch-backend) | backend layer for i18next using browsers fetch
 [i18next.gettext](https://github.com/palamccc/i18next.gettext) | gettext backend of i18next
 [nodejs filesystem](https://github.com/i18next/i18next-node-fs-backend) | node.js backend layer for i18next using fs module to load resources from filesystem
-[nodejs filesystem (sync)](https://github.com/arve0/i18next-sync-fs-backend) | node.js backend layer for i18next using fs module to load resources synchronous from filesystem
+[nodejs filesystem (sync)](https://github.com/sallar/i18next-sync-fs-backend) | node.js backend layer for i18next using fs module to load resources synchronous from filesystem
 [nodejs remote](https://github.com/i18next/i18next-node-remote-backend) | node.js backend layer for i18next using request module to load resources from another server
 [nodejs mongodb](https://github.com/gian788/i18next-node-mongodb-backend) | i18next node.js backend layer for i18next using mongodb
 [nodejs couchbase](https://github.com/kvaillant/i18next.couchbase) | i18next node.js backend layer for i18next using couchbase


### PR DESCRIPTION
The `i18next-sync-fs-backend` package has been transferred to another owner (me), and the namespace has been changed. This PR is reflecting that change.