### PR TITLE
Add link to essentials in "t" function documentation.

### DIFF
--- a/api.md
+++ b/api.md
@@ -69,7 +69,7 @@ i18next
 
 `i18next.t(key, options)`
 
-Please have a look at the translation functions like [interpolation](/interpolation.md), [formatting](/formatting.md) and [plurals](/plurals.md) for more details on using it.
+Please read more about it in [essentials](/essentials.md) and have a look at the translation functions like [interpolation](/interpolation.md), [formatting](/formatting.md) and [plurals](/plurals.md) for more details on using it.
 
 
 {% sample lang="js" %}


### PR DESCRIPTION
Documentation for `t` function options is located in "essentials" section but `t` function section at API page does not contain link to "essentials".