### PR TITLE
Update api.md

### DIFF
--- a/api.md
+++ b/api.md
@@ -420,6 +420,12 @@ Gets fired when resources got removed.
 Gets fired when changeLanguage got called.
 
 
+## off
+
+`i18next.off('languageChanged', previouslyAddedListenerFunction)`
+
+Unregisters a previously registered event listener.
+
 ---------
 
 # resource handling


### PR DESCRIPTION
it's not clear from the docs that the i18next object extends EventEmitter and that an event de-registration mechanism exists.

Changes to specific verbiage are most welcome.  I'm a developer, not a writer.