### PR TITLE
Add a missing quote in the addResouceBundle usage example

### DIFF
--- a/add-or-load-translations.md
+++ b/add-or-load-translations.md
@@ -52,7 +52,7 @@ You can add the translations after init
 import i18next from 'i18next';
 
 i18next.init();
-i18next.addResouceBundle('en, 'namespace1', {
+i18next.addResouceBundle('en', 'namespace1', {
   key: 'hello from namespace 1'
 });
 ```


### PR DESCRIPTION
Hello!

I've noticed a missing quote - this pull request adds it.