### PR TITLE
Updating API docs for i18next.languages to be more detailed

### DIFF
--- a/overview/api.md
+++ b/overview/api.md
@@ -337,7 +337,7 @@ Gets one value by given key.
 options:
 
 | option | default | description |
-| :--- | :--- | :--- |
+| --- | --- | --- |
 | keySeparator | "." | char to separate keys, or false if no separator is prefered |
 
 ### addResource
@@ -349,7 +349,7 @@ Adds one key/value.
 options:
 
 | option | default | description |
-| :--- | :--- | :--- |
+| --- | --- | --- |
 | keySeparator | "." | char to separate keys, or false if no separator is prefered |
 | silent | false | if set to true adding will not emit an added event |
 

--- a/overview/api.md
+++ b/overview/api.md
@@ -124,7 +124,26 @@ If you need the primary used language depending on your configuration \(whilelis
 
 `i18next.languages`
 
-Is set to an array of language-codes that will be used it order to lookup the translation value.
+Is set to an array of language codes that will be used to look up the translation value.
+
+When the language is set, this array is populated with the new language codes. Unless overridden, this array is populated with less-specific versions of that code for fallback purposes, followed by the list of fallback languages.
+
+{% hint style="info" %}
+Values are unique, so if they appear earlier in the array, they will not be added again.
+{% endhint %}
+
+```javascript
+// initialize with fallback languages
+i18next.init({
+  fallbackLng: ["es", "fr", "en-US", "dev"]
+});
+
+// change the language
+i18next.changeLanguage("en-US-xx");
+
+// languages has been updated
+i18next.languages; // ["en-US-xx", "en-US", "en", "es", "fr", "dev"]
+```
 
 ### loadNamespaces
 
@@ -318,7 +337,7 @@ Gets one value by given key.
 options:
 
 | option | default | description |
-| --- | --- | --- |
+| :--- | :--- | :--- |
 | keySeparator | "." | char to separate keys, or false if no separator is prefered |
 
 ### addResource
@@ -330,7 +349,7 @@ Adds one key/value.
 options:
 
 | option | default | description |
-| --- | --- | --- |
+| :--- | :--- | :--- |
 | keySeparator | "." | char to separate keys, or false if no separator is prefered |
 | silent | false | if set to true adding will not emit an added event |
 


### PR DESCRIPTION
This should be accurate, if I understood the source code.

Not sure if I like using "en-US-xx", as that's not real, but I couldn't find any examples of variant-level langtags when I looked.