### PR TITLE
Moving namespace fallback above language fallback, as it occurs first

### DIFF
--- a/principles/fallback.md
+++ b/principles/fallback.md
@@ -5,34 +5,6 @@
 Doing graceful fallbacks are a core principle of i18next. This enables you to display the most accurate content possible.
 
 
-#### fallback language
-
-If you can not provide the preferred language for a user you can specify a fallback language.
-
-```javascript
-// fallback to one language
-i18next.init({
-    fallbackLng: 'en'
-});
-
-// fallback ordered
-i18next.init({
-    fallbackLng: ['fr', 'en']
-});
-
-// fallback depending on user language
-i18next.init({
-    fallbackLng: { 
-        'de-CH': ['fr', 'it'], 
-        'zh-HANT': ['zh-HANS', 'en'],
-        'es': ['fr'],
-        'default': ['en']
-    }
-});
-```
-
-The default is set to `dev` which means developer language. At first this might look strange to set the default to a language but this enables to set the saveMissing feature to send new keys to that developer specific language. From there your translators can modify the texts to a translation file containing eg. proper english including defined terminology. For production just set fallbackLng to an existing language.
-
 ### namespace fallback
 
 i18next per default loads it translations from one file named `translation`. But you can set and structure it to load from multiple files, we call this files namespaces.
@@ -117,6 +89,34 @@ i18next.init({
   i18next.t('i18n', { lng: 'en' } ); // -> "Internationalization"
 });
 ```
+
+#### fallback language
+
+If you can not provide the preferred language for a user you can specify a fallback language.
+
+```javascript
+// fallback to one language
+i18next.init({
+    fallbackLng: 'en'
+});
+
+// fallback ordered
+i18next.init({
+    fallbackLng: ['fr', 'en']
+});
+
+// fallback depending on user language
+i18next.init({
+    fallbackLng: { 
+        'de-CH': ['fr', 'it'], 
+        'zh-HANT': ['zh-HANS', 'en'],
+        'es': ['fr'],
+        'default': ['en']
+    }
+});
+```
+
+The default is set to `dev` which means developer language. At first this might look strange to set the default to a language but this enables to set the saveMissing feature to send new keys to that developer specific language. From there your translators can modify the texts to a translation file containing eg. proper english including defined terminology. For production just set fallbackLng to an existing language.
 
 ### key fallback
 

--- a/principles/fallback.md
+++ b/principles/fallback.md
@@ -4,43 +4,6 @@
 
 Doing graceful fallbacks are a core principle of i18next. This enables you to display the most accurate content possible.
 
-### language fallback
-
-#### locals resolving
-
-Per default locals containing region or script will take a translation from the pure language file if not found.
-
-en-GB.json
-
-```javascript
-{
-  "i18n": "Internationalisation"
-}
-```
-
-en.json
-
-```javascript
-{
-  "i18n": "Internationalization",
-  "i18n_short": "i18n"
-}
-```
-
-Sample
-
-```javascript
-// fallback to one language
-i18next.init({
-    lng: 'en-GB'
-}, () => {
-  i18next.t('i18n'); // -> "Internationalisation"
-  i18next.t('i18n_short'); // -> "i18n" (from en.json)
-
-  // force loading en
-  i18next.t('i18n', { lng: 'en' } ); // -> "Internationalization"
-});
-```
 
 #### fallback language
 
@@ -114,6 +77,44 @@ i18next.init({
     // without fallbackNS you would have to prefix namespace 
     // to access keys in that namespace
     i18next.t('common:button.save') // -> "save"
+});
+```
+
+### language fallback
+
+#### locals resolving
+
+Per default locals containing region or script will take a translation from the pure language file if not found.
+
+en-GB.json
+
+```javascript
+{
+  "i18n": "Internationalisation"
+}
+```
+
+en.json
+
+```javascript
+{
+  "i18n": "Internationalization",
+  "i18n_short": "i18n"
+}
+```
+
+Sample
+
+```javascript
+// fallback to one language
+i18next.init({
+    lng: 'en-GB'
+}, () => {
+  i18next.t('i18n'); // -> "Internationalisation"
+  i18next.t('i18n_short'); // -> "i18n" (from en.json)
+
+  // force loading en
+  i18next.t('i18n', { lng: 'en' } ); // -> "Internationalization"
 });
 ```
 


### PR DESCRIPTION
I plan on making the entire flow of i18next very transparent, but this is the first step in my eyes