### PR TITLE
Fix backend.read/readMulti examples

### DIFF
--- a/misc/creating-own-plugins.md
+++ b/misc/creating-own-plugins.md
@@ -25,15 +25,15 @@ Backend plugins are used to load data for i18next.
   },
   read: function(language, namespace, callback) {
     /* return resources */
-    return {
+    callback(null, {
       key: 'value'
-    };
+    });
   },
 
   // optional
   readMulti: function(languages, namespaces, callback) {
     /* return multiple resources - usefull eg. for bundling loading in one xhr request */
-    return {
+    callback(null, {
       en: {
         translations: {
           key: 'value'
@@ -44,7 +44,7 @@ Backend plugins are used to load data for i18next.
           key: 'value'
         }
       }
-    }
+    });
   },
 
   // only used in backends acting as cache layer


### PR DESCRIPTION
The code (at tag `v2.0.0`) doesn't use the return values from `read()` or `readMulti()`, only the results passed to `callback()`, so I've updated the docs to reflect that.