### PR TITLE
Mention babel-plugin-i18next-extract in utils

### DIFF
--- a/overview/plugins-and-utils.md
+++ b/overview/plugins-and-utils.md
@@ -25,6 +25,7 @@ While the i18next format \(JSON based\) is the preferred solution and widely sup
 | [i18next-parser](https://github.com/i18next/i18next-parser) | extractor | A simple command line and gulp plugin that lets you parse your code and extract the translations keys in it. |
 | [i18nextResourceGenerator](https://github.com/DREEBIT/i18nextResourceGenerator) | extractor | Intellij IDEA Plugin for i18next resource generation |
 | [aurelia-i18next-parser](https://github.com/gooy/aurelia-i18next-parser) | extractor | Extracts i18n keys and values from source files. |
+| [babel-plugin-i18next-extract](https://github.com/gilbsgilbs/babel-plugin-i18next-extract) | extractor | A babel plugin that can extract keys from your code in JSONv3 format. |
 | [grunt-i18next](https://github.com/i18next/grunt-i18next) | bundler | bundle language resource files for i18next |
 | [i18next-po-loader](https://github.com/queicherius/i18next-po-loader) | bundler | Load gettext PO files as i18next format directly in webpack |
 | [i18next-loader](https://github.com/kamilglod/i18next-loader) | bundler | webpack loader that can translate your code and generate bundle per each language |

--- a/overview/plugins-and-utils.md
+++ b/overview/plugins-and-utils.md
@@ -14,6 +14,14 @@ While the i18next format \(JSON based\) is the preferred solution and widely sup
 | [i18next-icu](https://github.com/i18next/i18next-icu) | ICU | i18nFormat plugin to use ICU format with i18next based on [yahoo/intl-messageformat](https://github.com/yahoo/intl-messageformat) |
 | [i18next-polyglot](https://github.com/i18next/i18next-polyglot) | polyglot | i18nFormat plugin to use [airbnb/polyglot.js](https://github.com/airbnb/polyglot.js) format with i18next |
 
+### extraction tools
+
+| **name** | **description** |
+| :--- | :--- |
+| [i18next-scanner](http://i18next.github.io/i18next-scanner) | Scan your code, extract translation keys/values, and merge them into i18n resource files. |
+| [i18next-parser](https://github.com/i18next/i18next-parser) | A simple command line and gulp plugin that lets you parse your code and extract the translations keys in it. |
+| [babel-plugin-i18next-extract](https://github.com/gilbsgilbs/babel-plugin-i18next-extract) | A babel plugin that can extract keys in JSONv3 format. |
+
 ### utils
 
 | **util** | **type** | **description** |
@@ -21,11 +29,8 @@ While the i18next format \(JSON based\) is the preferred solution and widely sup
 | [i18next-gettext-converter](https://github.com/i18next/i18next-gettext-converter) | converter | Converts gettext .mo or .po to 18next json format and vice versa. |
 | [csv2i18next](https://github.com/tmorozov/csv2i18next) | converter | Convert CSV files to JSON & YAML for i18next.js |
 | [resx2i18next](https://github.com/rolandpd/resx2i18next) | converter | Convert ResX-files to json resources compatible with i18next |
-| [i18next-scanner](http://i18next.github.io/i18next-scanner) | extractor | Scan your code, extract translation keys/values, and merge them into i18n resource files. |
-| [i18next-parser](https://github.com/i18next/i18next-parser) | extractor | A simple command line and gulp plugin that lets you parse your code and extract the translations keys in it. |
 | [i18nextResourceGenerator](https://github.com/DREEBIT/i18nextResourceGenerator) | extractor | Intellij IDEA Plugin for i18next resource generation |
 | [aurelia-i18next-parser](https://github.com/gooy/aurelia-i18next-parser) | extractor | Extracts i18n keys and values from source files. |
-| [babel-plugin-i18next-extract](https://github.com/gilbsgilbs/babel-plugin-i18next-extract) | extractor | A babel plugin that can extract keys from your code in JSONv3 format. |
 | [grunt-i18next](https://github.com/i18next/grunt-i18next) | bundler | bundle language resource files for i18next |
 | [i18next-po-loader](https://github.com/queicherius/i18next-po-loader) | bundler | Load gettext PO files as i18next format directly in webpack |
 | [i18next-loader](https://github.com/kamilglod/i18next-loader) | bundler | webpack loader that can translate your code and generate bundle per each language |


### PR DESCRIPTION
Hi,

I wasn't satisfied with existing static extraction tools for i18next. I tried `i18next-scanner` and `i18next-parser` and they both completely or partially rely on dirty regular expressions, have incomplete support for namespaces, have a very naive implementation of contexts (supporting only `_male` and `_female` suffixes, missing what context really is about). `i18next-parser` seemed slightly better to me (although it does rely on regexes for some processing), still it requires to configure another parser (acorn) from scratch which I didn't want to do because Babel is already setup almost everywhere.

For those reasons, I decided to come up with [my very own solution](https://github.com/gilbsgilbs/babel-plugin-i18next-extract) based on Babel plugin API. This is a personal project that I tried on a tiny react project we have at work. I'd like to get some attention from the community to see if it can also solve problems other people may encounter or have encountered and if it's worth improving it further. In particular, I think what I called [comment hints](https://github.com/gilbsgilbs/babel-plugin-i18next-extract/tree/3370fc0ccb896b487111b7cb340039c182f007f2#comment-hints) might be useful to some.

Let me know if you like it and if you'd like to include it in the gitbook :smile: .

Keep up the great work :+1: .