### PR TITLE
Add i18next-cli-language-detector to plugins-and-utils.md

### DIFF
--- a/overview/plugins-and-utils.md
+++ b/overview/plugins-and-utils.md
@@ -93,6 +93,7 @@ While the i18next format \(JSON based\) is the preferred solution and widely sup
 | [react native](https://github.com/DylanVann/i18next-react-native-language-detector) | language detector for React Native. |
 | [react native Async Storage](https://github.com/0xClpz/i18next-react-native-async-storage) | language detector for React Native that saves the user's choice in Async Storage, used for persistance. |
 | [electron](https://github.com/neruchev/i18next-electron-language-detector) | language detector for electron apps. |
+| [CLI](https://github.com/neet/i18next-cli-language-detector) | language detector for CLI. |
 
 ### post processors
 


### PR DESCRIPTION
[i18next-cli-language-detector](https://npm.im/i18next-cli-language-detector) is a third-party language detector for CLI which I made.  I'm glad if you list it in the documentation.