### PR TITLE
docs: fix heading

### DIFF
--- a/overview/configuration-options.md
+++ b/overview/configuration-options.md
@@ -116,7 +116,9 @@ All options for calling init or createInstance.
       </td>
     </tr>
   </tbody>
-</table>#### initImmediate
+</table>
+
+### initImmediate
 
 Sample using initImmediate when using a backend plugin allowing sync \(blocking\) loads.
 


### PR DESCRIPTION
The heading was displaying incorrectly and breaking the display of the preceding table.