### PR TITLE
Add a note that not passing second arg to 'off' unsubscribes all listeners.

### DIFF
--- a/overview/api.md
+++ b/overview/api.md
@@ -330,6 +330,10 @@ const newInstance = i18next.cloneInstance({
 Every event can be unsubscribed using
 
 `i18next.off('name', myFunction);`
+
+All attached listeners can be unsubscribed using
+
+`i18next.off('name');`
 {% endhint %}
 
 ### onInitialized


### PR DESCRIPTION
Not sure if that's intended behavior but if it's I think it's worth to add this note.

I wasn't aware of this and this reflected in a hard to track bug. Long story short, when second argument passed to 'off' is undefined, all existing listeners will be removed. As listeners are tightly coupled to `react-i18next`, some of `useTranslation` hooks suddenly stopped triggering the update when internal `react-i18next` context changed.

![wtf2](https://user-images.githubusercontent.com/9931428/82032908-3e268d80-969c-11ea-84da-9aa4cb330097.gif)

