### PR TITLE
Update nesting.md to remove quotes on count variables

### DIFF
--- a/translation-function/nesting.md
+++ b/translation-function/nesting.md
@@ -32,8 +32,8 @@ keys
 
 ```javascript
 {
-      "girlsAndBoys": "$t(girls, {\"count\": \"{{girls}}\" }) and {{count}} boy",
-      "girlsAndBoys_plural": "$t(girls, {\"count\": \"{{girls}}\" }) and {{count}} boys",
+      "girlsAndBoys": "$t(girls, {\"count\": {{girls}} }) and {{count}} boy",
+      "girlsAndBoys_plural": "$t(girls, {\"count\": {{girls}} }) and {{count}} boys",
       "girls": "{{count}} girl",
       "girls_plural": "{{count}} girls"
 }


### PR DESCRIPTION
Count should not be quoted because it turns into a string and does not pluralize correctly.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [ ] only relevant code is changed (make a diff before you submit the PR)
- [ ] run tests `npm run test`
- [ ] tests are included
- [x] documentation is changed or added