### PR TITLE
Fix erroneous code in error interpolation example

### DIFF
--- a/overview/comparison-to-others.md
+++ b/overview/comparison-to-others.md
@@ -90,7 +90,7 @@ translation.json
 ```javascript
 {
     "error": {
-        "unspecific": "Something went wrong.",
+        "502": "Something went wrong.",
         "404": "The page was not found."
     }
 }


### PR DESCRIPTION
The code directly below my code change declares 2 const variables, with values `404` and `502`, respectively. Without this fix, the code sample would log `undefined` since `502` is not a key in the provided map.

#### Checklist

- [X] only relevant code is changed (make a diff before you submit the PR)
- [-] ~~run tests `npm run test`~~
- [-] ~~tests are included~~
- [x] documentation is changed or added