### PR TITLE
Add Handlebars to the supported frameworks

### DIFF
--- a/overview/supported-frameworks.md
+++ b/overview/supported-frameworks.md
@@ -44,6 +44,8 @@
 | webcomponent | [i18next-wc](https://github.com/spurreiter/i18next-wc) | Web components interfacing i18next and Intl |
 | marko.js | [marko-i18next](https://github.com/gunjam/marko-i18next) | Components to use i18next in Marko templates. |
 | virtualdom | [i18nextify](https://github.com/i18next/i18nextify) | one liner script to enable i18next on any site |
+| Handlebars | [handlebars-i18next](https://github.com/UUDigitalHumanitieslab/handlebars-i18next) | Handlebars helper that lets you translate with i18next inside your templates.
+| Handlebars | [handlebars-i18n](https://github.com/fwalzel/handlebars-i18n) | adds the internationalization features of i18next and Intl to handlebars.js.
 
 ## Supported Environments
 


### PR DESCRIPTION
I created the [handlebars-i18next](https://www.npmjs.com/package/handlebars-i18next) package about two years ago, but didn't think of adding it to the list at the time. It appears that some people weren't able to find it, as @fwalzel states that Handlebars "is not in the list of i18next's supported Frameworks" and seems to have reinvented the wheel with [handlebars-i18n](https://www.npmjs.com/package/handlebars-i18n) for this reason. This pull request adds both packages to the list.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [ ] ~run tests `npm run test`~ (not applicable)
- [ ] ~tests are included~ (not applicable)
- [x] documentation is changed or added