### PR TITLE
Fix german grammar

### DIFF
--- a/locales/de/special.json
+++ b/locales/de/special.json
@@ -1,3 +1,3 @@
 {
-    "title": "{{what}} in deutsch"
+    "title": "{{what}} auf Deutsch"
 }


### PR DESCRIPTION
'in' in German refers only to location. 'auf' is in this case used to refer to the language. `auf Deutsch` meaning in the language German and `in Deutsch` would mean inside the location `Deutsch`. also, capitalize Deutsch.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [ ] run tests `npm run test`
- [ ] tests are included
- [ ] documentation is changed or added