### PR TITLE
Add plugin example for Webpack code splitting

### DIFF
--- a/overview/plugins-and-utils.md
+++ b/overview/plugins-and-utils.md
@@ -210,6 +210,12 @@ While the i18next format \(JSON based\) is the preferred solution and widely sup
         <a
         href="http://locize.com">locize.com - localization as a service</a>.</td>
     </tr>
+    <tr>
+      <td style="text-align:left"><a href="https://gist.github.com/SimeonC/6a738467c691eef7f21ebf96918cd95f">webpack import backend</a>
+      </td>
+      <td style="text-align:left">Use webpack code splitting to load files as a javascript bundle</a>
+      </td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
As outlined in this discussion (https://github.com/i18next/i18next/discussions/1611), adding the gist example to the docs.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [ ] run tests `npm run test`
- [ ] tests are included
- [ ] documentation is changed or added