### PR TITLE
Fix broken links in config + ref "cache docs"

### DIFF
--- a/overview/configuration-options.md
+++ b/overview/configuration-options.md
@@ -64,7 +64,7 @@ All options for calling `init()` or `createInstance()`.
 | :--- | :--- | :--- |
 | detection | undefined | options for language detection - [check docs](plugins-and-utils.md#language-detector) |
 | backend | undefined | options for backend - [check docs](plugins-and-utils.md#backends) |
-| cache | undefined | options for a cache layer - check documentation of plugin |
+| cache | undefined | options for a cache layer in backends - [check docs](plugins-and-utils.md#backends) |
 
 ### Others
 

--- a/overview/configuration-options.md
+++ b/overview/configuration-options.md
@@ -62,8 +62,8 @@ All options for calling `init()` or `createInstance()`.
 
 | option | default | description |
 | :--- | :--- | :--- |
-| detection | undefined | options for language detection - [check docs](https://github.com/i18next/i18next-gitbook/tree/c874a56e8aa1bf16de562d44eda1f22450492fd4/overview/overview/plugins-and-utils/README.md#language-detector) |
-| backend | undefined | options for backend - [check docs](https://github.com/i18next/i18next-gitbook/tree/c874a56e8aa1bf16de562d44eda1f22450492fd4/overview/overview/plugins-and-utils/README.md#backends) |
+| detection | undefined | options for language detection - [check docs](plugins-and-utils.md#language-detector) |
+| backend | undefined | options for backend - [check docs](plugins-and-utils.md#backends) |
 | cache | undefined | options for a cache layer - check documentation of plugin |
 
 ### Others


### PR DESCRIPTION
Not sure what happened... I guess the Gitbook editor you use made some weird references? (I'm using Typora, a generic Markdown editor)

It's funny that it also creates some weird formatting, such as escaping parentheses (never saw that in Markdown before) and closing and reopening formatting between links and plain text... lol