### PR TITLE
improve ordinal plural docs

### DIFF
--- a/translation-function/plurals.md
+++ b/translation-function/plurals.md
@@ -95,27 +95,29 @@ _Or try_ [_translation-check_](https://github.com/locize/translation-check)_, it
 
 ## Ordinal plurals
 
-There is also support for ordinal numbers _(referring to the ordering or ranking of things, e.g. "1st", "2nd", "3rd" in English)_.
+There is also support for ordinal numbers _(referring to the ordering or ranking of things, e.g. "1st", "2nd", "3rd" in English)_. The `ordinal` option tells the helper to use the ordinal digit
+to determine the plurality key used. E.g., for "32" the ordinal digit is "2" so `key_two` is used.
 
 keys
 
 ```javascript
-// i.e. italian
+// i.e. english
 {
-  "key_one": "singular", // cardinal form
-  "key_other": "other", // cardinal form
-  "key_many": "many" // ordinal form
+  "key_one": "{{count}}st place", // 1st, 21st, 31st
+  "key_two": "{{count}}nd place", // 2nd, 22nd, 32nd
+  "key_few": "{{count}}rd place", // 3rd, 23rd, 33rd
+  "key_other": "{{count}}th place" // 4th, 5th, 24th, 11th
 }
 ```
 
 sample
 
 ```javascript
-i18next.t('key', {count: 0}); // -> "other"
-i18next.t('key', {count: 1}); // -> "singular"
-i18next.t('key', {count: 2}); // -> "other"
-i18next.t('key', {count: 11}); // -> "other"
-i18next.t('key', {count: 11, ordinal: true}); // -> "many"
+i18next.t('key', { count: 1, ordinal: true }); // -> "1st place"
+i18next.t('key', { count: 21, ordinal: true }); // -> "21st place"
+i18next.t('key', { count: 2, ordinal: true }); // -> "2nd place"
+i18next.t('key', { count: 11, ordinal: true }); // -> "11th place"
+i18next.t('key', { count: 32, ordinal: true }); // -> "32nd place"
 ```
 
 ## Interval plurals


### PR DESCRIPTION
## Motivation:

I had a really hard time understanding the existing docs for getting ordinal plurals to work. After much trial and error, I figured it out, and I believe these docs make it much clearer.


#### Checklist (for documentation change)

- [x] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)