### PR TITLE
`babel-plugin-i18next-extract` now supports v4

### DIFF
--- a/overview/plugins-and-utils.md
+++ b/overview/plugins-and-utils.md
@@ -18,7 +18,7 @@ While the i18next format (JSON based) is the preferred solution and widely suppo
 | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
 | [i18next-scanner](http://i18next.github.io/i18next-scanner)                                | Scan your code, extract translation keys/values, and merge them into i18n resource files.                    |
 | [i18next-parser](https://github.com/i18next/i18next-parser)                                | A simple command line and gulp plugin that lets you parse your code and extract the translations keys in it. |
-| [babel-plugin-i18next-extract](https://github.com/gilbsgilbs/babel-plugin-i18next-extract) | A babel plugin that can extract keys in JSONv3 format.                                                       |
+| [babel-plugin-i18next-extract](https://github.com/gilbsgilbs/babel-plugin-i18next-extract) | A babel plugin that can extract keys in JSONv4 format.                                                       |
 | [translation-check](https://github.com/locize/translation-check)                           | Nicely shows an overview of your translations in a UI. Check which keys are not yet translated.              |
 
 ## utils


### PR DESCRIPTION
See https://github.com/gilbsgilbs/babel-plugin-i18next-extract/pull/214

<img width="745" alt="image" src="https://user-images.githubusercontent.com/1459385/215873806-d3322fd2-3059-46c9-91d1-77a7158df933.png">


#### Checklist

- ~[ ] only relevant code is changed (make a diff before you submit the PR)~
- ~[ ] run tests `npm run test`~
- ~[ ] tests are included~
- ~[ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)~

#### Checklist (for documentation change)

- [x] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)