### PR TITLE
Add plugin to plugins-and-utils.md

### DIFF
--- a/overview/plugins-and-utils.md
+++ b/overview/plugins-and-utils.md
@@ -97,17 +97,18 @@ Services that are known to fully support the i18next format (plural handling, ..
 
 ## language detector
 
-| **language** **detector**                                                                  | **description**                                                                                                            |
-| ------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
-| [universal (browser + nodejs)](https://github.com/UnlyEd/universal-language-detector)      | Language detector that works universally (browser + server) - Meant to be used with a universal framework, such as Next.js |
-| [browser](https://github.com/i18next/i18next-browser-languageDetector)                     | language detector used in browser environment for i18next                                                                  |
-| [http](https://github.com/i18next/i18next-http-middleware)                                 | language detector for "any" http backend, also for Deno                                                                    |
-| [nodejs express](https://github.com/i18next/i18next-express-middleware)                    | language detector for express.js (nodejs).                                                                                 |
-| [nodejs koa](https://github.com/lxzxl/koa-i18next-detector)                                | A i18next language detecting plugin for Koa framework.                                                                     |
-| [react native](https://github.com/DylanVann/i18next-react-native-language-detector)        | language detector for React Native.                                                                                        |
-| [react native Async Storage](https://github.com/0xClpz/i18next-react-native-async-storage) | language detector for React Native that saves the user's choice in Async Storage, used for persistence.                    |
-| [electron](https://github.com/neruchev/i18next-electron-language-detector)                 | language detector for electron apps.                                                                                       |
-| [CLI](https://github.com/neet/i18next-cli-language-detector)                               | language detector for CLI.                                                                                                 |
+| **language** **detector**                                                                          | **description**                                                                                                            |
+| -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| [universal (browser + nodejs)](https://github.com/UnlyEd/universal-language-detector)              | Language detector that works universally (browser + server) - Meant to be used with a universal framework, such as Next.js |
+| [browser](https://github.com/i18next/i18next-browser-languageDetector)                             | language detector used in browser environment for i18next                                                                  |
+| [http](https://github.com/i18next/i18next-http-middleware)                                         | language detector for "any" http backend, also for Deno                                                                    |
+| [nodejs express](https://github.com/i18next/i18next-express-middleware)                            | language detector for express.js (nodejs).                                                                                 |
+| [nodejs koa](https://github.com/lxzxl/koa-i18next-detector)                                        | A i18next language detecting plugin for Koa framework.                                                                     |
+| [react native localization settings](https://github.com/jakex7/react-native-localization-settings) | language detector for React Native that uses native per-app language API to enable language change in system preferences.  |
+| [react native](https://github.com/DylanVann/i18next-react-native-language-detector)                | language detector for React Native.                                                                                        |
+| [react native Async Storage](https://github.com/0xClpz/i18next-react-native-async-storage)         | language detector for React Native that saves the user's choice in Async Storage, used for persistence.                    |
+| [electron](https://github.com/neruchev/i18next-electron-language-detector)                         | language detector for electron apps.                                                                                       |
+| [CLI](https://github.com/neet/i18next-cli-language-detector)                                       | language detector for CLI.                                                                                                 |
 
 ## post processors
 


### PR DESCRIPTION
I've added `react-native-localization-settings` to list of plugins in language-detector section.
[*react-native-localization-settings*](https://github.com/jakex7/react-native-localization-settings) is a 18next plugin for react-native that apart from language detection (compatible with i18next out-of-the-box) are exposing native API (iOS and Android) for changing language in system settings (per-app language preferences). I think it might be useful for others to include this in a documentation because it helps to build the native user-experience in react-native apps. Here is the screenshot of how it looks: 

![cover-i18next](https://user-images.githubusercontent.com/39670088/231262058-e4d19746-a991-4a3f-aa6e-964a4dc0e198.png)

#### Checklist (for documentation change)

- [X] only relevant documentation part is changed (make a diff before you submit the PR)
- [X] motivation/reason is provided
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)